### PR TITLE
Use SPEC constr optimization on recursive compose func

### DIFF
--- a/unicode-transforms.cabal
+++ b/unicode-transforms.cabal
@@ -90,6 +90,7 @@ library
       base >=4.7 && <5
     , bytestring >=0.9 && <0.11
     , text >=1.1.1 && <1.3
+    , ghc-prim >= 0.2 && < 0.7
   if flag(dev)
     ghc-options: -O0
   else


### PR DESCRIPTION
```
Benchmark       unicode-transforms(0)(ms) unicode-transforms(1)(ms)
--------------- ------------------------- -------------------------
NFC/AllChars                        21.94                     18.65
NFC/Deutsch                         15.94                     12.92
NFC/Devanagari                      20.09                     16.06
NFC/English                         15.26                     12.22
NFC/Japanese                        23.92                     19.87
NFC/Korean                          23.62                     20.62
NFC/Vietnamese                      21.37                     18.02

NFKC/AllChars                       27.52                     23.55
NFKC/Deutsch                        16.76                     13.11
NFKC/Devanagari                     20.14                     16.68
NFKC/English                        15.81                     12.14
NFKC/Japanese                       25.09                     21.31
NFKC/Korean                         24.19                     21.01
NFKC/Vietnamese                     21.79                     18.21
```