### PR TITLE
refactor decomposeChar

### DIFF
--- a/Data/Unicode/Internal/NormalizeStream.hs
+++ b/Data/Unicode/Internal/NormalizeStream.hs
@@ -121,28 +121,28 @@ decomposeChar mode marr index reBuf ch
         j <- writeReorderBuffer marr index reBuf
         (, Empty) <$> decomposeCharHangul marr j ch
     | D.isDecomposable mode ch =
-        decomposeAll index reBuf (D.decomposeChar mode ch)
+        decomposeAll marr index reBuf (D.decomposeChar mode ch)
     | otherwise =
-        reorder index reBuf ch
+        reorder marr index reBuf ch
 
     where
 
     {-# INLINE decomposeAll #-}
-    decomposeAll i rbuf [] = return (i, rbuf)
-    decomposeAll i rbuf (x : xs)
+    decomposeAll _ i rbuf [] = return (i, rbuf)
+    decomposeAll arr i rbuf (x : xs)
         | D.isDecomposable mode x = do
-            (i', rbuf') <- decomposeAll i rbuf (D.decomposeChar mode x)
-            decomposeAll i' rbuf' xs
+            (i', rbuf') <- decomposeAll arr i rbuf (D.decomposeChar mode x)
+            decomposeAll arr i' rbuf' xs
         | otherwise  = do
-            (i', rbuf') <- reorder i rbuf x
-            decomposeAll i' rbuf' xs
+            (i', rbuf') <- reorder arr i rbuf x
+            decomposeAll arr i' rbuf' xs
 
     {-# INLINE reorder #-}
-    reorder i rbuf c
+    reorder arr i rbuf c
         | CC.isCombining c = return (i, insertIntoReBuf c rbuf)
         | otherwise = do
-            j <- writeReorderBuffer marr i rbuf
-            n <- unsafeWrite marr j c
+            j <- writeReorderBuffer arr i rbuf
+            n <- unsafeWrite arr j c
             return (j + n, Empty)
 
 -- | /O(n)/ Convert a 'Text' into a 'Stream Char'.


### PR DESCRIPTION
@Bodigrim I think there were three crucial differences in the original version and your refactored version which may have caused the perf regression:

1) The original code unfolded the case where the char is decomposable outside the loop.
2) The original code is not using list concatenation instead it uses recursion to handle that, so it utilizes the stack, we know that decomposition cannot result in unlimited or very large number of chars, so this works well in practice.
3) Your code had a issue because of the placement of isCombining check.

I have just reorganized the old code by using guards so that it looks neater. I am trying a few more changes, so this is a draft as of now.