### PR TITLE
Use straight through branches

### DIFF
--- a/Data/Unicode/Properties/DecomposeHangul.hs
+++ b/Data/Unicode/Properties/DecomposeHangul.hs
@@ -10,6 +10,7 @@
 module Data.Unicode.Properties.DecomposeHangul
     (decomposeCharHangul
     , hangulFirst
+    , hangulLast
     , isHangul
     , isHangulLV
     , isJamo
@@ -20,6 +21,7 @@ module Data.Unicode.Properties.DecomposeHangul
     , jamoTFirst
     , jamoTCount
     , jamoTIndex
+    , jamoLast
     )
 where
 


### PR DESCRIPTION
Instead of discarding the results of branches in range checks arrange
them such that we always fall through to the next case in else. This gives a
modest performance improvement.

Percent improvement (-ve) and regression (+ve):

```
Benchmark       unicode-transforms(0)(ms)(base) unicode-transforms(1)(%)(-base)
--------------- ------------------------------- -------------------------------
NFC/AllChars                              10.53                           -2.95
NFC/Deutsch                                3.34                           -7.84
NFC/Devanagari                             7.66                           -9.07
NFC/English                                2.56                          -12.86
NFC/Japanese                              12.53                           +3.77
NFC/Korean                                12.94                           +0.91
NFC/Vietnamese                            11.19                           -4.06
NFD/AllChars                               6.58                           -2.78
NFD/Deutsch                                2.29                           +0.11
NFD/Devanagari                             6.34                           +0.09
NFD/English                                1.72                           +2.00
NFD/Japanese                               7.92                           +0.21
NFD/Korean                                16.33                           -0.03
NFD/Vietnamese                             6.06                           -0.22
NFKC/AllChars                             15.70                           -4.78
NFKC/Deutsch                               3.52                          -11.63
NFKC/Devanagari                            7.67                           -8.47
NFKC/English                               2.56                          -12.47
NFKC/Japanese                             13.41                           +0.26
NFKC/Korean                               13.41                           +0.14
NFKC/Vietnamese                           11.26                           -6.53
NFKD/AllChars                              9.88                           -0.77
NFKD/Deutsch                               2.30                           -0.52
NFKD/Devanagari                            6.38                          +19.91
NFKD/English                               1.78                           +0.67
NFKD/Japanese                              8.39                           -0.10
NFKD/Korean                               16.36                           +1.41
NFKD/Vietnamese                            6.17                          +10.64
```

Not sure why NFKD regressed, may be due to code layout changes due to the change of code and/or some test variance.