### PR TITLE
Do not import Data.Text.Internal.Unsafe.Shift

### DIFF
--- a/Data/Unicode/Internal/NormalizeStream.hs
+++ b/Data/Unicode/Internal/NormalizeStream.hs
@@ -22,6 +22,7 @@ module Data.Unicode.Internal.NormalizeStream
     )
     where
 
+import           Data.Bits                              (shiftR)
 import           Data.Char                              (chr, ord)
 import qualified Data.Text.Array                        as A
 import           Data.Text.Internal                     (Text (..))
@@ -32,7 +33,6 @@ import           Data.Text.Internal.Fusion.Types        (Step (..), Stream (..))
 import           Data.Text.Internal.Private             (runText)
 import           Data.Text.Internal.Unsafe.Char         (unsafeWrite)
 import           Data.Text.Internal.Unsafe.Char         (unsafeChr)
-import           Data.Text.Internal.Unsafe.Shift        (shiftR)
 import           GHC.ST                                 (ST (..))
 import           GHC.Types                              (SPEC(..))
 


### PR DESCRIPTION
`Data.Text.Internal.Unsafe.Shift` has been removed in https://github.com/haskell/text/commit/a1f974cd517f548c5b658d1605cb9498fbcff95e
