### PR TITLE
Bump the upper bound of unicode-data

### DIFF
--- a/unicode-transforms.cabal
+++ b/unicode-transforms.cabal
@@ -83,7 +83,7 @@ library
   ghc-options: -Wall -fwarn-identities -fwarn-incomplete-record-updates -fwarn-incomplete-uni-patterns -fwarn-tabs
   build-depends:
       base         >= 4.8 && < 5
-    , unicode-data >= 0.2 && < 0.3
+    , unicode-data >= 0.2 && < 0.4
     , bytestring   >= 0.9 && < 0.12
     , ghc-prim     >= 0.2 && < 0.9
 
@@ -130,7 +130,7 @@ test-suite quickcheck
   ghc-options: -Wall -fwarn-identities -fwarn-incomplete-record-updates -fwarn-incomplete-uni-patterns -fwarn-tabs
   build-depends:
       QuickCheck   >= 2.1   && < 2.15
-    , unicode-data >= 0.2   && < 0.3
+    , unicode-data >= 0.2   && < 0.4
     , base         >= 4.7   && < 5
     , deepseq      >= 1.1   && < 1.5
     , hspec        >= 2.0   && < 3

--- a/unicode-transforms.cabal
+++ b/unicode-transforms.cabal
@@ -82,7 +82,7 @@ library
   hs-source-dirs: .
   ghc-options: -Wall -fwarn-identities -fwarn-incomplete-record-updates -fwarn-incomplete-uni-patterns -fwarn-tabs
   build-depends:
-      base         >= 4.8 && < 5
+      base         >= 4.8 && < 4.17
     , unicode-data >= 0.2 && < 0.4
     , bytestring   >= 0.9 && < 0.12
     , ghc-prim     >= 0.2 && < 0.9
@@ -108,7 +108,7 @@ test-suite extras
   ghc-options: -Wall -fwarn-identities -fwarn-incomplete-record-updates -fwarn-incomplete-uni-patterns -fwarn-tabs
   build-depends:
       QuickCheck >=2.1 && <2.15
-    , base >=4.7 && <5
+    , base >=4.7 && <4.17
     , deepseq >=1.1 && <1.5
     , text
     , unicode-transforms
@@ -131,7 +131,7 @@ test-suite quickcheck
   build-depends:
       QuickCheck   >= 2.1   && < 2.15
     , unicode-data >= 0.2   && < 0.4
-    , base         >= 4.7   && < 5
+    , base         >= 4.7   && < 4.17
     , deepseq      >= 1.1   && < 1.5
     , hspec        >= 2.0   && < 3
     , text
@@ -155,7 +155,7 @@ test-suite ucd
       test
   ghc-options: -Wall -fwarn-identities -fwarn-incomplete-record-updates -fwarn-incomplete-uni-patterns -fwarn-tabs
   build-depends:
-      base >=4.7 && <5
+      base >=4.7 && <4.17
     , bytestring
     , split >=0.1 && <0.3
     , text
@@ -175,7 +175,7 @@ benchmark bench
       benchmark
   ghc-options: -Wall -fwarn-identities -fwarn-incomplete-record-updates -fwarn-incomplete-uni-patterns -fwarn-tabs
   build-depends:
-      base >=4.7 && <5
+      base >=4.7 && <4.17
     , deepseq >=1.1.0 && <1.5
     , filepath >=1.0 && <2
     , path >=0.0.0 && <0.9
@@ -209,7 +209,7 @@ executable chart
   if flag(bench-show)
     buildable: True
     build-Depends:
-        base >= 4.8 && < 5
+        base >= 4.8 && < 4.17
       , bench-show >= 0.3 && < 0.4
       , split >= 0.2 && < 0.3
       , transformers >= 0.4   && < 0.6


### PR DESCRIPTION
- Used in normalization
- Essentially the normalization helpers did not change over the versions
- Admit 0.3.*