### PR TITLE
Add support for GHC 9.6 and update CI

### DIFF
--- a/.github/workflows/packcheck.yml
+++ b/.github/workflows/packcheck.yml
@@ -86,8 +86,9 @@ jobs:
       fail-fast: false
       matrix:
         name:
-          - 9.4.2
-          - 9.2.4
+          - 9.6.1
+          - 9.4.4
+          - 9.2.7
           - 9.0.2
           - 8.10.7
           - 8.10.7+stack
@@ -97,14 +98,20 @@ jobs:
           - 8.2.2
           - 8.0.2
         include:
-          - name: 9.4.2
-            ghc-version: 9.4.2
+          - name: 9.6.1
+            ghc-version: 9.6.1
             command: cabal-v2
             runner: ubuntu-latest
-            cabal-version: 3.6
+            cabal-version: 3.10.1.0
 
-          - name: 9.2.4
-            ghc-version: 9.2.4
+          - name: 9.4.4
+            ghc-version: 9.4.4
+            command: cabal-v2
+            runner: ubuntu-latest
+            cabal-version: 3.8.1.0
+
+          - name: 9.2.7
+            ghc-version: 9.2.7
             command: cabal-v2
             runner: ubuntu-latest
             cabal-version: 3.6
@@ -167,15 +174,15 @@ jobs:
           #     HLINT_TARGETS="Data"
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
-    - uses: haskell/actions/setup@v1
+    - uses: haskell/actions/setup@v2
       with:
         ghc-version: ${{ matrix.ghc-version }}
         cabal-version: ${{ matrix.cabal-version }}
 
 
-    - uses: actions/cache@v2
+    - uses: actions/cache@v3
       name: Cache common directories
       with:
         path: |

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,7 +1,12 @@
+## (Unreleased)
+
+* Support GHC 9.4 and 9.6: allow `base 4.18` and `ghc-prim 0.10`
+* Support `unicode-data 0.4`
+
 ## 0.4.0.1 (March 2022)
 
-* Support text-icu == 0.8.* in tests
-* Support unicode-data == 0.3.*
+* Support `text-icu == 0.8.*` in tests
+* Support `unicode-data == 0.3.*`
 
 ## 0.4.0 (November 2021)
 
@@ -12,7 +17,7 @@
 
 ## 0.3.8
 
-* Allow ghc-prim 0.7
+* Allow `ghc-prim 0.7`
 * Extract `unicode-data` into its own package
 * Depend on the latest stable `text`
 

--- a/unicode-transforms.cabal
+++ b/unicode-transforms.cabal
@@ -21,8 +21,8 @@ tested-with:    GHC==8.0.2
               , GHC==8.8.4
               , GHC==8.10.7
               , GHC==9.0.2
-              , GHC==9.2.4
-              , GHC==9.4.2
+              , GHC==9.2.7
+              , GHC==9.4.4
 build-type:     Simple
 extra-source-files:
     Changelog.md
@@ -83,10 +83,10 @@ library
   hs-source-dirs: .
   ghc-options: -Wall -fwarn-identities -fwarn-incomplete-record-updates -fwarn-incomplete-uni-patterns -fwarn-tabs
   build-depends:
-      base         >= 4.8 && < 4.18
+      base         >= 4.8 && < 4.19
     , unicode-data >= 0.2 && < 0.5
     , bytestring   >= 0.9 && < 0.12
-    , ghc-prim     >= 0.2 && < 0.10
+    , ghc-prim     >= 0.2 && < 0.11
 
     -- We depend on a lot of internal modules in text. We keep the upper bound
     -- inclusive of the latest stable version.


### PR DESCRIPTION
Fixes #92. If sufficient, it will only require a Hackage revision.