### PR TITLE
Support ghc 9.10

### DIFF
--- a/.github/workflows/packcheck.yml
+++ b/.github/workflows/packcheck.yml
@@ -188,7 +188,7 @@ jobs:
           #     HLINT_TARGETS="Data"
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - uses: haskell-actions/setup@v2
       with:
@@ -196,7 +196,7 @@ jobs:
         cabal-version: ${{ matrix.cabal-version }}
 
 
-    - uses: actions/cache@v3
+    - uses: actions/cache@v4
       name: Cache common directories
       with:
         path: |

--- a/.github/workflows/packcheck.yml
+++ b/.github/workflows/packcheck.yml
@@ -86,6 +86,7 @@ jobs:
       fail-fast: false
       matrix:
         name:
+          - 9.10.1
           - 9.8.1
           - 9.6.3
           - 9.4.7
@@ -99,6 +100,12 @@ jobs:
           - 8.2.2
           - 8.0.2
         include:
+          - name: 9.10.1
+            ghc-version: 9.10.1
+            command: cabal-v2
+            runner: ubuntu-latest
+            cabal-version: 3.10.1.0
+
           - name: 9.8.1
             ghc-version: 9.8.1
             command: cabal-v2

--- a/.github/workflows/s390x.yml
+++ b/.github/workflows/s390x.yml
@@ -18,7 +18,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - uses: uraimo/run-on-arch-action@v2.1.1
       timeout-minutes: 60
       with:

--- a/unicode-transforms.cabal
+++ b/unicode-transforms.cabal
@@ -25,6 +25,7 @@ tested-with:    GHC==8.0.2
               , GHC==9.4.7
               , GHC==9.6.3
               , GHC==9.8.1
+              , GHC==9.10.1
 build-type:     Simple
 extra-source-files:
     Changelog.md
@@ -85,7 +86,7 @@ library
   hs-source-dirs: .
   ghc-options: -Wall -fwarn-identities -fwarn-incomplete-record-updates -fwarn-incomplete-uni-patterns -fwarn-tabs
   build-depends:
-      base         >= 4.8 && < 4.20
+      base         >= 4.8 && < 4.21
     , unicode-data >= 0.2 && < 0.5
     , bytestring   >= 0.9 && < 0.13
     , ghc-prim     >= 0.2 && < 0.12

--- a/unicode-transforms.cabal
+++ b/unicode-transforms.cabal
@@ -27,13 +27,14 @@ tested-with:    GHC==8.0.2
               , GHC==9.8.1
               , GHC==9.10.1
 build-type:     Simple
-extra-source-files:
+extra-doc-files:
     Changelog.md
     MAINTAINING.md
     NOTES.md
     README.md
-    download-ucd-files.sh
     benchmark/README.md
+extra-source-files:
+    download-ucd-files.sh
     benchmark/NormalizeFile.hs
     benchmark/data/AllChars.txt
     benchmark/data/Deutsch.txt


### PR DESCRIPTION
- Bump upper bound on base to include `4.21`
- Add GHC 9.10.1 to the versions tested in CI
- Update the `actions/checkout` and `actions/cache` actions to version v4. Older versions lead to warnings in the Github Actions tab.
- Use `extra-doc-files` instead of `extra-source-files` in the cabal file for files which don't need to trigger recompilation.