### PR TITLE
Support GHC 9.12

### DIFF
--- a/.github/workflows/packcheck.yml
+++ b/.github/workflows/packcheck.yml
@@ -86,6 +86,7 @@ jobs:
       fail-fast: false
       matrix:
         name:
+          - 9.12.1
           - 9.10.1
           - 9.8.1
           - 9.6.3
@@ -100,6 +101,12 @@ jobs:
           - 8.2.2
           - 8.0.2
         include:
+          - name: 9.12.1
+            ghc-version: 9.12.1
+            command: cabal-v2
+            runner: ubuntu-latest
+            cabal-version: 3.14.1.1
+
           - name: 9.10.1
             ghc-version: 9.10.1
             command: cabal-v2

--- a/.github/workflows/packcheck.yml
+++ b/.github/workflows/packcheck.yml
@@ -160,12 +160,16 @@ jobs:
             command: cabal-v2
             runner: ubuntu-latest
             cabal-version: 3.2
+            pack_options: >-
+              DISABLE_BENCH=y
 
           - name: 8.4.4
             ghc-version: 8.4.4
             command: cabal-v2
             runner: ubuntu-latest
             cabal-version: 3.2
+            pack_options: >-
+              DISABLE_BENCH=y
 
           - name: 8.2.2
             ghc-version: 8.2.2

--- a/Data/Unicode/Types.hs
+++ b/Data/Unicode/Types.hs
@@ -19,7 +19,9 @@ module Data.Unicode.Types
       NormalizationMode(..)
     ) where
 
+#if __GLASGOW_HASKELL__ < 912
 import           Data.Typeable (Typeable)
+#endif
 
 -- |
 -- Normalization transforms Unicode text into an equivalent
@@ -95,4 +97,8 @@ data NormalizationMode
     | NFKD   -- ^ Compatibility decomposition.
     | NFC    -- ^ Canonical decomposition followed by canonical composition.
     | NFKC   -- ^ Compatibility decomposition followed by canonical composition.
-      deriving (Eq, Show, Enum, Typeable)
+      deriving (Eq, Show, Enum
+#if __GLASGOW_HASKELL__ < 912
+                  , Typeable
+#endif
+               )

--- a/unicode-transforms.cabal
+++ b/unicode-transforms.cabal
@@ -87,10 +87,10 @@ library
   hs-source-dirs: .
   ghc-options: -Wall -fwarn-identities -fwarn-incomplete-record-updates -fwarn-incomplete-uni-patterns -fwarn-tabs
   build-depends:
-      base         >= 4.8 && < 4.21
+      base         >= 4.8 && < 4.22
     , unicode-data >= 0.2 && < 0.7
     , bytestring   >= 0.9 && < 0.13
-    , ghc-prim     >= 0.2 && < 0.12
+    , ghc-prim     >= 0.2 && < 0.14
 
     -- We depend on a lot of internal modules in text. We keep the upper bound
     -- inclusive of the latest stable version.

--- a/unicode-transforms.cabal
+++ b/unicode-transforms.cabal
@@ -112,7 +112,7 @@ test-suite extras
       test
   ghc-options: -Wall -fwarn-identities -fwarn-incomplete-record-updates -fwarn-incomplete-uni-patterns -fwarn-tabs
   build-depends:
-      QuickCheck >=2.1 && <2.15
+      QuickCheck >=2.1 && <2.16
     , base
     , deepseq >=1.1 && <1.6
     , text
@@ -190,7 +190,7 @@ benchmark bench
   if flag(use-gauge)
     build-depends: gauge >=0.2.0 && <0.3
   else
-    build-depends: tasty-bench>= 0.2.5 && <0.4
+    build-depends: tasty-bench>= 0.2.5 && <0.5
     mixins: tasty-bench (Test.Tasty.Bench as Gauge.Main)
   if flag(dev)
     ghc-options: -O0


### PR DESCRIPTION
GHC 9.12 uses base 4.21 and ghc-prim 0.13; I also

When compiling with GHC 9.12.1, I got GHC-90584. I'm not a Haskell
programmer, so I made the simplest changes that could work — I don't
know how one would make the `deriving Typeable` conditional based on
GHC version or if there would be some other way to do that.
